### PR TITLE
Formendpoint: Fix typehint for show_in_menu to allow strings

### DIFF
--- a/src/Formendpoint.php
+++ b/src/Formendpoint.php
@@ -107,7 +107,12 @@ class Formendpoint
         return $this;
     }
 
-    public function show_in_menu(bool $showInMenu): Formendpoint
+    /**
+     * Set the 'show_in_menu' argument to the register_post_type call.
+     *
+     * @param bool|string $showInMenu
+     */
+    public function show_in_menu($showInMenu): Formendpoint
     {
         $this->showInMenu = $showInMenu;
 


### PR DESCRIPTION
The `bool` typehint caused old valid uses that pass a string to throw an error after updating. This removes the typehint and instead adds a phpdoc annotation, matching the type expected by the underlying WordPress argument.